### PR TITLE
Allow files to be specified, don't replace with directories anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ grunt.initConfig({
 
 So, in your target, don't forget to add `src` and `dest` properties. The `dest` property is optional, and is defaulting to `"./doc"`.
 
-**Note:** as **Codo** seems to expect folders path instead of files list, if files are given, the task will use their dirname as source.
-
 ### Options
 
 #### options.stats
@@ -204,6 +202,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 * [bartsidee](https://github.com/bartsidee)
 * [leny](https://github.com/leny)
+* [hildjj](https://github.com/hildjj))
 
 ## License
 Copyright (c) 2014 Johannes Stein  

--- a/src/codo.coffee
+++ b/src/codo.coffee
@@ -39,10 +39,8 @@ module.exports = ( grunt ) ->
         @filesSrc
             .filter ( sFilePath ) ->
                 grunt.file.exists sFilePath
-            # .forEach ( sFilePath ) ->
-            #     # As codo seems to expect folders path instead of files, we will use dirname of given files, and store them into aFolderSources
-            #     return aFolderSources.push sFilePath if grunt.file.isDir sFilePath
-            #     return aFolderSources.push path.dirname sFilePath if grunt.file.isFile sFilePath
+            .forEach ( sFilePath ) ->
+                return aFolderSources.push sFilePath
 
         aFolderSources = lodash.uniq aFolderSources
 

--- a/src/codo.coffee
+++ b/src/codo.coffee
@@ -39,10 +39,10 @@ module.exports = ( grunt ) ->
         @filesSrc
             .filter ( sFilePath ) ->
                 grunt.file.exists sFilePath
-            .forEach ( sFilePath ) ->
-                # As codo seems to expect folders path instead of files, we will use dirname of given files, and store them into aFolderSources
-                return aFolderSources.push sFilePath if grunt.file.isDir sFilePath
-                return aFolderSources.push path.dirname sFilePath if grunt.file.isFile sFilePath
+            # .forEach ( sFilePath ) ->
+            #     # As codo seems to expect folders path instead of files, we will use dirname of given files, and store them into aFolderSources
+            #     return aFolderSources.push sFilePath if grunt.file.isDir sFilePath
+            #     return aFolderSources.push path.dirname sFilePath if grunt.file.isFile sFilePath
 
         aFolderSources = lodash.uniq aFolderSources
 

--- a/tasks/codo.js
+++ b/tasks/codo.js
@@ -41,13 +41,6 @@ module.exports = function(grunt) {
     aFolderSources = [];
     this.filesSrc.filter(function(sFilePath) {
       return grunt.file.exists(sFilePath);
-    }).forEach(function(sFilePath) {
-      if (grunt.file.isDir(sFilePath)) {
-        return aFolderSources.push(sFilePath);
-      }
-      if (grunt.file.isFile(sFilePath)) {
-        return aFolderSources.push(path.dirname(sFilePath));
-      }
     });
     aFolderSources = lodash.uniq(aFolderSources);
     oCodo = new Codo(aFolderSources, oOptions);

--- a/tasks/codo.js
+++ b/tasks/codo.js
@@ -41,6 +41,8 @@ module.exports = function(grunt) {
     aFolderSources = [];
     this.filesSrc.filter(function(sFilePath) {
       return grunt.file.exists(sFilePath);
+    }).forEach(function(sFilePath) {
+      return aFolderSources.push(sFilePath);
     });
     aFolderSources = lodash.uniq(aFolderSources);
     oCodo = new Codo(aFolderSources, oOptions);


### PR DESCRIPTION
Codo no longer requires directories for its inputs.  This patch removes the filtering down to dirname that you applied.  Fixed docs to match.  Ran tests and lint.
